### PR TITLE
[ASE-0000] Add linux rollup dependency for CICD runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "access": "restricted"
   },
   "optionalDependencies": {
-    "@rollup/rollup-darwin-arm64": "^4.46.2"
+    "@rollup/rollup-darwin-arm64": "^4.46.2",
+    "@rollup/rollup-linux-x64-gnu": "^4.46.2"
   }
 }


### PR DESCRIPTION
Fixes an error in actions where rollup can not be executed due to a missing optional dependency