### PR TITLE
chore: set verbatimModuleSyntax to true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "typescript": "^5.1.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-darwin-arm64": "^4.46.2"
+        "@rollup/rollup-darwin-arm64": "^4.46.2",
+        "@rollup/rollup-linux-x64-gnu": "^4.46.2"
       },
       "peerDependencies": {
         "@mui/joy": ">=5.0.0",
@@ -2817,6 +2818,19 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@sinclair/typebox": {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button as JoyButton, ButtonProps as JoyButtonProps } from "@mui/joy";
+import { Button as JoyButton } from "@mui/joy";
+import type { ButtonProps as JoyButtonProps } from "@mui/joy";
 
 export interface ButtonProps extends Omit<JoyButtonProps, "variant"> {
   variant?: "solid" | "soft" | "outlined" | "plain";

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,10 +1,6 @@
 import React from "react";
-import {
-  Card as JoyCard,
-  CardProps as JoyCardProps,
-  CardContent,
-  Typography,
-} from "@mui/joy";
+import { Card as JoyCard, CardContent, Typography } from "@mui/joy";
+import type { CardProps as JoyCardProps } from "@mui/joy";
 
 export interface CardProps extends Omit<JoyCardProps, "variant"> {
   variant?: "soft" | "outlined" | "solid" | "plain";

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import {
   Input as JoyInput,
-  InputProps as JoyInputProps,
   FormControl,
   FormLabel,
   FormHelperText,
 } from "@mui/joy";
+import type { InputProps as JoyInputProps } from "@mui/joy";
 
 export interface InputProps extends Omit<JoyInputProps, "variant"> {
   variant?: "soft" | "outlined" | "solid" | "plain";

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,4 +1,5 @@
-import { CssVarsThemeOptions, extendTheme } from "@mui/material";
+import { extendTheme } from "@mui/material";
+import type { CssVarsThemeOptions } from "@mui/material";
 
 export const createCustomTheme = (
   customizations?: CssVarsThemeOptions | undefined

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",
-    "module": "esnext"
+    "module": "esnext",
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
This add the ´verbatimModuleSyntax´ to the tsconfig and sets it to true. 
This is for consistency with the frontend-template and for best practice. 

This solves #6 