### PR TITLE
Fix FileChip text truncation issue

### DIFF
--- a/src/components/FileChip/FileChip.tsx
+++ b/src/components/FileChip/FileChip.tsx
@@ -218,7 +218,6 @@ const FileChip: React.FC<FileChipProps> = ({
               whiteSpace: "nowrap",
               overflow: "hidden",
               textOverflow: "ellipsis",
-              maxWidth: "300px",
             }}
             title={filename}
           >


### PR DESCRIPTION
## Summary
- Removed hardcoded `maxWidth: "300px"` from Typography component in FileChip
- Text now uses full available container space before truncating
- Ellipsis (...) only appears when text actually reaches container edge

## Changes
- Modified `src/components/FileChip/FileChip.tsx:221` to remove artificial width constraint

## Test Plan
- Verify FileChip components display full filename when space is available
- Confirm truncation only occurs at actual container boundaries
- Test with various filename lengths and container sizes

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)